### PR TITLE
feat: only push docker image if platform credentials are defined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,47 +38,65 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          # docker_layer_caching: true
           version: 18.06.0-ce
       - attach_workspace:
           at: .
       - run:
           name: Build Docker Image
-          command: docker build -f Dockerfile.circle . -t sofietv/tv-automation-playout-gateway:$CIRCLE_TAG
+          command: docker build -f Dockerfile.circle . -t playout-gateway:$CIRCLE_TAG
       - run:
            name: Publish Docker Image to Docker Hub
            command: |
-             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-             docker push sofietv/tv-automation-playout-gateway:$CIRCLE_TAG
+             if [ -z "$DOCKERHUB_PASS" ]; then
+               echo "Skipping"
+             else
+               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+               docker tag playout-gateway:$CIRCLE_TAG $DOCKERHUB_IMAGE:$CIRCLE_TAG
+               docker push $DOCKERHUB_IMAGE:$CIRCLE_TAG
+             fi
       - run:
            name: Publish Docker Image to Github Package Registry
            command: |
-             echo "$GITHUB_PASS" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
-             docker tag sofietv/tv-automation-playout-gateway:$CIRCLE_TAG docker.pkg.github.com/nrkno/tv-automation-playout-gateway/tv-automation-playout-gateway:$CIRCLE_TAG
-             docker push docker.pkg.github.com/nrkno/tv-automation-playout-gateway/tv-automation-playout-gateway:$CIRCLE_TAG
+             if [ -z "$GITHUB_PASS" ]; then
+               echo "Skipping"
+             else
+               echo "$GITHUB_PASS" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
+               docker tag playout-gateway:$CIRCLE_TAG docker.pkg.github.com/$GITHUB_IMAGE:$CIRCLE_TAG
+               docker push docker.pkg.github.com/$GITHUB_IMAGE:$CIRCLE_TAG
+             fi
   publish-branch:
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          # docker_layer_caching: true
           version: 18.06.0-ce
       - attach_workspace:
           at: .
       - run:
           name: Build Docker Image
-          command: docker build -f Dockerfile.circle . -t sofietv/tv-automation-playout-gateway:$CIRCLE_BRANCH
+          command: docker build -f Dockerfile.circle . -t playout-gateway:$CIRCLE_BRANCH
       - run:
            name: Publish Docker Image to Docker Hub
            command: |
-             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-             docker push sofietv/tv-automation-playout-gateway:$CIRCLE_BRANCH
+             if [ -z "$DOCKERHUB_PASS" ]; then
+               echo "Skipping"
+             else
+               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+               docker tag playout-gateway:$CIRCLE_BRANCH $DOCKERHUB_IMAGE:$CIRCLE_BRANCH
+               docker push $DOCKERHUB_IMAGE:$CIRCLE_BRANCH
+             fi
       - run:
            name: Publish Docker Image to Github Package Registry
            command: |
-             echo "$GITHUB_PASS" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
-             docker tag sofietv/tv-automation-playout-gateway:$CIRCLE_BRANCH docker.pkg.github.com/nrkno/tv-automation-playout-gateway/tv-automation-playout-gateway:$CIRCLE_BRANCH
-             docker push docker.pkg.github.com/nrkno/tv-automation-playout-gateway/tv-automation-playout-gateway:$CIRCLE_BRANCH
+             if [ -z "$GITHUB_PASS" ]; then
+               echo "Skipping"
+             else
+               echo "$GITHUB_PASS" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
+               docker tag playout-gateway:$CIRCLE_BRANCH docker.pkg.github.com/$GITHUB_IMAGE:$CIRCLE_BRANCH
+               docker push docker.pkg.github.com/$GITHUB_IMAGE:$CIRCLE_BRANCH
+             fi
 
 workflows:
   version: 2


### PR DESCRIPTION
This simply only pushes images to dockerhub and github registry if there are credentials defined for that platform. It also takes the image name to use from a variable, to allow forkers to easily push to their own repos without causing any circleci config conflicts

This has already been done in core.

In circleci the following variables will need to be defined:
DOCKERHUB_IMAGE=sofietv/tv-automation-playout-gateway
GITHUB_IMAGE=nrkno/tv-automation-playout-gateway/tv-automation-playout-gateway