### PR TITLE
fix: remove uninitialised device

### DIFF
--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -539,18 +539,21 @@ export class CoreHandler {
 export class CoreTSRDeviceHandler {
 	core: CoreConnection
 	public _observers: Array<any> = []
+	public _devicePr: Promise<DeviceContainer>
+	public _deviceId: string
 	public _device: DeviceContainer
 	private _coreParentHandler: CoreHandler
 	private _tsrHandler: TSRHandler
 	private _subscriptions: Array<string> = []
 	private _hasGottenStatusChange: boolean = false
 
-	constructor (parent: CoreHandler, device: DeviceContainer, tsrHandler: TSRHandler) {
+	constructor (parent: CoreHandler, device: Promise<DeviceContainer>, deviceId: string, tsrHandler: TSRHandler) {
 		this._coreParentHandler = parent
-		this._device = device
+		this._devicePr = device
+		this._deviceId = deviceId
 		this._tsrHandler = tsrHandler
 
-		this._coreParentHandler.logger.info('new CoreTSRDeviceHandler ' + device.deviceName)
+		// this._coreParentHandler.logger.info('new CoreTSRDeviceHandler ' + device.deviceName)
 
 		// this.core = new CoreConnection(parent.getCoreConnectionOptions('MOS: ' + device.idPrimary, device.idPrimary, false))
 		// this.core.onError((err) => {
@@ -558,6 +561,7 @@ export class CoreTSRDeviceHandler {
 		// })
 	}
 	async init (): Promise<void> {
+		this._device = await this._devicePr
 		let deviceName = this._device.deviceName
 		let deviceId = this._device.deviceId
 
@@ -634,7 +638,7 @@ export class CoreTSRDeviceHandler {
 			obs.stop()
 		})
 
-		await this._tsrHandler.tsr.removeDevice(this._device.deviceId)
+		await this._tsrHandler.tsr.removeDevice(this._deviceId)
 		await this.core.setStatus({
 			statusCode: P.StatusCode.BAD,
 			messages: ['Uninitialized']

--- a/src/tsrHandler.ts
+++ b/src/tsrHandler.ts
@@ -583,14 +583,16 @@ export class TSRHandler {
 				throw new Error(`There is already a _coreTsrHandlers for deviceId "${deviceId}"!`)
 			}
 
-			const device: DeviceContainer = await this.tsr.addDevice(deviceId, options)
+			const devicePr: Promise<DeviceContainer> = this.tsr.addDevice(deviceId, options)
+
+			let coreTsrHandler = new CoreTSRDeviceHandler(this._coreHandler, devicePr, deviceId, this)
+
+			this._coreTsrHandlers[deviceId] = coreTsrHandler
+
+			const device = await devicePr
 
 			// Set up device status
 			const deviceType = device.deviceType
-
-			let coreTsrHandler = new CoreTSRDeviceHandler(this._coreHandler, device, this)
-
-			this._coreTsrHandlers[deviceId] = coreTsrHandler
 
 			const onConnectionChanged = (connectedOrStatus: boolean | P.StatusObject) => {
 				let deviceStatus: P.StatusObject


### PR DESCRIPTION
Previously a not yet initialised device would not be saved on the TSRHandler class and therefore could not be removed either.

This PR fixes that by having the CoreTSRDeviceHandler take a promise instead of a DeviceContainer.