### PR TITLE
fix: take full ownership of atem media uploading

### DIFF
--- a/src/atemUploader.ts
+++ b/src/atemUploader.ts
@@ -104,6 +104,11 @@ singleton.connect(process.argv[2]).then(async () => {
 		singleton.mediaPool = parseInt(mediaPool, 10)
 	}
 
+	if (isNaN(singleton.mediaPool) || singleton.mediaPool === undefined) {
+		console.error('Exiting due to invalid mediaPool')
+		process.exit(-1)
+	}
+
 	singleton.uploadToAtem().then(() => {
 		consoleLog('uploaded ATEM media to pool ' + singleton.mediaPool)
 		process.exit(0)

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -6,7 +6,6 @@ import { CoreConnection,
 	PeripheralDeviceAPI
 } from 'tv-automation-server-core-integration'
 
-import * as cp from 'child_process'
 import {
 	DeviceType,
 	CasparCGDevice,
@@ -376,39 +375,6 @@ export class CoreHandler {
 	pingResponse (message: string) {
 		this.core.setPingResponse(message)
 		return true
-	}
-	/**
-	 * This function is a quick and dirty solution to load a still to the atem mixers.
-	 * This does not serve as a proper implementation! And need to be refactor
-	 * // @todo: proper atem media management
-	 * /Balte - 22-08
-	 */
-	uploadFileToAtem (urls: { _key: string, value: any }[]) {
-
-		urls.forEach((url, index) => {
-			this.logger.info('try to load ' + JSON.stringify(url) + ' to atem')
-			if (this._tsrHandler) {
-				this._tsrHandler.tsr.getDevices().forEach(async (device) => {
-					if (device.deviceType === DeviceType.ATEM) {
-						const options = (device.deviceOptions).options as { host: string }
-						this.logger.info('options ' + JSON.stringify(options))
-						if (options && options.host) {
-							this.logger.info('uploading ' + url.value + ' to ' + options.host + ' in MP' + index)
-							const process = cp.spawn(`node`, [`./dist/atemUploader.js`, options.host, url.value, url._key])
-							process.stdout.on('data', (data) => this.logger.info(data.toString()))
-							process.stderr.on('data', (data) => this.logger.info(data.toString()))
-							process.on('close', () => {
-								process.removeAllListeners()
-							})
-						} else {
-							throw Error('ATEM host option not set')
-						}
-					}
-				})
-			} else {
-				throw Error('TSR not set up!')
-			}
-		})
 	}
 	getSnapshot (): any {
 		this.logger.info('getSnapshot')


### PR DESCRIPTION
Partner: https://github.com/nrkno/tv-automation-server-core/pull/197

This takes better ownership of the atem media uploading process.
It can no longer be triggered by core, as that could currently happen with a different set of data to the internal upload calls. This data from core would actually trigger some uploads to slot `NaN`, and surprisingly those uploads have no effect, even though it appears the atem library made no attempt to skip them

Additionally, uploads will be attempted even when the device status is a warning, as the device could still be useable in these scenarios (eg, only 1 of 2 psu has power)