### PR TITLE
feat: Viz clear command config manifest

### DIFF
--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -324,6 +324,11 @@ const PLAYOUT_SUBDEVICE_CONFIG: SubDeviceConfigManifest['config'] = {
 			id: 'options.initializeRundownOnLoadAll',
 			name: 'On preload-All elements, also initialize the rundown playlist again',
 			type: ConfigManifestEntryType.BOOLEAN
+		},
+		{
+			id: 'options.clearAllCommands',
+			name: 'Clear All Channels Commands',
+			type: ConfigManifestEntryType.MULTILINE_STRING
 		}
 	]
 }


### PR DESCRIPTION
Adds the config manifest entry for Viz clear commands. These are plain-text commands sent to clear and reset viz layers.

Requires https://github.com/nrkno/tv-automation-server-core/pull/257
Requires https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/152