### PR TITLE
Feat: Update and clear Media Objects

### DIFF
--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -591,7 +591,13 @@ export class CoreTSRDeviceHandler {
 			docId,
 			doc
 		])
-		.catch(e => this._coreParentHandler.logger.error('Error when updating Media Object: ' + JSON.stringify(e), e))
+		.catch(e => this._coreParentHandler.logger.error('Error when updating Media Object: ' + e, e.stack))
+	}
+	onClearMediaObjectCollection (collectionId: string) {
+		this.core.callMethodLowPrio(PeripheralDeviceAPI.methods.clearMediaObjectCollection, [
+			collectionId
+		])
+		.catch(e => this._coreParentHandler.logger.error('Error when clearing Media Objects collection: ' + e, e.stack))
 	}
 
 	async dispose (): Promise<void> {

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -11,7 +11,8 @@ import {
 	CasparCGDevice,
 	DeviceContainer,
 	HyperdeckDevice,
-	QuantelDevice
+	QuantelDevice,
+	MediaObject
 } from 'timeline-state-resolver'
 
 import * as _ from 'underscore'
@@ -583,6 +584,14 @@ export class CoreTSRDeviceHandler {
 			ref
 		])
 		.catch(e => this._coreParentHandler.logger.error('Error when setting status: ' + e, e.stack))
+	}
+	onUpdateMediaObject (collectionId: string, docId: string, doc: MediaObject | null) {
+		this.core.callMethodLowPrio(PeripheralDeviceAPI.methods.updateMediaObject, [
+			collectionId,
+			docId,
+			doc
+		])
+		.catch(e => this._coreParentHandler.logger.error('Error when updating Media Object: ' + JSON.stringify(e), e))
 	}
 
 	async dispose (): Promise<void> {

--- a/src/tsrHandler.ts
+++ b/src/tsrHandler.ts
@@ -13,7 +13,8 @@ import {
 	TSRTimelineObjBase,
 	CommandReport,
 	DeviceOptionsAtem,
-	AtemMediaPoolType
+	AtemMediaPoolType,
+	MediaObject
 } from 'timeline-state-resolver'
 import { CoreHandler, CoreTSRDeviceHandler } from './coreHandler'
 let clone = require('fast-clone')
@@ -682,6 +683,9 @@ export class TSRHandler {
 				this.logger.error(error)
 				this.logger.debug(context)
 			}
+			const onUpdateMediaObject = (collectionId: string, docId: string, doc: MediaObject | null) => {
+				coreTsrHandler.onUpdateMediaObject(collectionId, docId, doc)
+			}
 			let deviceName = device.deviceName
 			let deviceInstanceId = device.instanceId
 			const fixError = (e) => {
@@ -720,6 +724,7 @@ export class TSRHandler {
 			await device.device.on('slowCommand', onSlowCommand)
 			await device.device.on('commandError', onCommandError)
 			await device.device.on('commandReport', onCommandReport)
+			await device.device.on('updateMediaObject', onUpdateMediaObject)
 
 			await device.device.on('info',	(e, ...args) => this.logger.info(fixError(e), ...args))
 			await device.device.on('warning',	(e, ...args) => this.logger.warn(fixError(e), ...args))

--- a/src/tsrHandler.ts
+++ b/src/tsrHandler.ts
@@ -686,6 +686,9 @@ export class TSRHandler {
 			const onUpdateMediaObject = (collectionId: string, docId: string, doc: MediaObject | null) => {
 				coreTsrHandler.onUpdateMediaObject(collectionId, docId, doc)
 			}
+			const onClearMediaObjectCollection = (collectionId: string) => {
+				coreTsrHandler.onClearMediaObjectCollection(collectionId)
+			}
 			let deviceName = device.deviceName
 			let deviceInstanceId = device.instanceId
 			const fixError = (e) => {
@@ -725,6 +728,7 @@ export class TSRHandler {
 			await device.device.on('commandError', onCommandError)
 			await device.device.on('commandReport', onCommandReport)
 			await device.device.on('updateMediaObject', onUpdateMediaObject)
+			await device.device.on('clearMediaObjects', onClearMediaObjectCollection)
 
 			await device.device.on('info',	(e, ...args) => this.logger.info(fixError(e), ...args))
 			await device.device.on('warning',	(e, ...args) => this.logger.warn(fixError(e), ...args))


### PR DESCRIPTION
This PR adds support for two events that can be emitted by a device, in order to manage documents in core's MediaObjects collection: 

- `updateMediaObject` - to create/update/delete a MediaObject
- `clearMediaObjects` - to remove all MediaObjects with a specific collectionId

Depends on: https://github.com/nrkno/tv-automation-server-core/pull/316 and https://github.com/nrkno/tv-automation-server-core-integration/pull/32