### PR TITLE
feat: zero-based configs for ATEM and Sisyfos devices

### DIFF
--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -410,7 +410,7 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			name: 'Mapping Type',
 			includeInSummary: true,
 		},
-		{ id: 'index', type: ConfigManifestEntryType.INT, name: 'index', includeInSummary: true },
+		{ id: 'index', type: ConfigManifestEntryType.INT, name: 'index', includeInSummary: true, zeroBased: true },
 	],
 	[TSRDeviceType.CASPARCG]: [
 		{
@@ -520,6 +520,7 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			name: 'Channel',
 			optional: true,
 			includeInSummary: true,
+			zeroBased: true,
 		},
 	],
 	// TODO - add VMix?


### PR DESCRIPTION
This PR marks Sisyfos channels and ATEM config values as being zero-based. See https://github.com/nrkno/tv-automation-server-core/pull/483 for details on what this means.